### PR TITLE
Radarr support and properties file instead of arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.log
 subs.wanted
+downloader.properties

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # sonarr-sub-downloader
-Sonarr custom post processor script for handling subtitle download.
+Sonarr & Radarr custom post processor script for handling subtitle download.
 
 # Summary
 This project contains 2 main bash scripts for handling Sonarr subtitle download after a TV show has been downloaded.
 
-The script [sub-downloader.sh](sub-downloader.sh) works perfectly as a [Custom Post Processor Script](2) for [Sonarr](1).
+The script [sub-downloader.sh](sub-downloader.sh) works perfectly as a [Custom Post Processor Script](2) for [Sonarr](1) and [Radarr](5).
 
 The script [search-wanted.sh](wanted/search-wanted.sh)` looks for those subtitles that were not found in previous executions of the first one.
 
@@ -18,22 +18,27 @@ Behind the scenes, both scripts uses [subliminal](3) as subtitle downloader engi
    ```
 
 # How to setup the script in Sonarr
-1. Download the [latest][4] release (zip or tar.gz) file.
-2. Uncompress the file
-
-         unzip sonarr-sub-downloader-0.1.zip
-         # or
-         tar -xvf sonarr-sub-downloader-0.1.tar.gz
+1. Clone this repo
 3. Open Sonarr, go to: `<your-sonar-host>:<port>/settings/connect`
 4. Click in the '+' => Custom Script
 5. Choose a name for your script, recommended: "Subs Downloader"
 6. Enable only "On Download"
 7. Choose the path in which the script `sub-downloader` has been cloned.
-8. The script requires 1 argument, a comma-separated language list for the subtitles to download, 
-   for example, for download English and Spanish subtitles: `-l es,en`
+8. The script requires `downloader.properties` to be present inside the repo. There's a template for you to copy. Example:
+
+```bash
+# Comma separated (e.g: es,en,it)
+languages=es
+
+# Credentials
+opensubtitles.credentials=myUsern4m3 coolPassword
+addic7ed.credentials=anotherUsername anotherPassword
+legendastv.credentials=
+```
+
 9. How the configuration should look like
 
-![alt example](https://raw.githubusercontent.com/ebergama/sonarr-sub-downloader/master/example/example.png)
+![alt example](http://i.imgur.com/Ym8NVue.png)
 
 # How to enable the not found searcher to run periodically
 1. Run [the installation script](wanted/install.sh) 
@@ -53,3 +58,4 @@ Ezequiel Bergamaschi - ezequielbergamaschi@gmail.com
 [2]: https://github.com/Sonarr/Sonarr/wiki/Custom-Post-Processing-Scripts
 [3]: https://github.com/Diaoul/subliminal
 [4]: https://github.com/ebergama/sonarr-sub-downloader/releases/latest
+[5]: https://radarr.video/

--- a/downloader.properties.template
+++ b/downloader.properties.template
@@ -1,0 +1,7 @@
+# Comma separated (e.g: es,en,it)
+languages=
+
+# Credentials
+opensubtitles.credentials=
+addic7ed.credentials=
+legendastv.credentials=

--- a/properties_parser.sh
+++ b/properties_parser.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+function prop {
+    grep "${1}" ${2} | cut -d '=' -f2
+}
+
+function propCredentials {
+    CREDENTIALS=''
+
+    OPENSUBTITLES_CREDENTIALS=`prop opensubtitles.credentials $1`
+    if ! [ -z "$OPENSUBTITLES_CREDENTIALS" ]; then
+        CREDENTIALS+="--opensubtitles $OPENSUBTITLES_CREDENTIALS "
+    fi
+
+    ADDICTED_CREDENTIALS=`prop addic7ed.credentials $1`
+    if ! [ -z "$ADDICTED_CREDENTIALS" ]; then
+        CREDENTIALS+="--addic7ed $ADDICTED_CREDENTIALS "
+    fi
+
+    LEGENDASTV_CREDENTIALS=`prop legendas.credentials $1`
+    if ! [ -z "$LEGENDASTV_CREDENTIALS" ]; then
+        CREDENTIALS+="--legendastv $LEGENDASTV_CREDENTIALS "
+    fi
+
+    echo $CREDENTIALS | xargs
+}
+
+function propLanguages {
+    LANGUAGES=`prop languages $1`
+
+    echo "-l $LANGUAGES"
+}
+

--- a/sub-downloader.sh
+++ b/sub-downloader.sh
@@ -61,7 +61,7 @@ subliminal download ${LANGUAGES} "${VIDEO_PATH}" >> $LOG_FILE 2>&1
 declare LANG_ARRAY=($(echo ${LANGUAGES} | sed "s/-l //g"))
 
 for LANG in "${LANG_ARRAY[@]}"; do
-  SUB_FILE="${VIDEO_PATH}.${LANG}.srt"
+  SUB_FILE="${VIDEO_PATH%.*}.${LANG}.srt"
   if [[ ! -f $SUB_FILE ]]; then
     doLog "Subtitle ${SUB_FILE} not found, adding it to wanted"
     echo $VIDEO_PATH:$SUB_FILE >> ${WANTED_FILE}

--- a/sub-downloader.sh
+++ b/sub-downloader.sh
@@ -43,7 +43,7 @@ doLog "###### Process started at: $(date) ######"
 declare VIDEO_PATH=${sonarr_episodefile_path}
 if [[ -z $VIDEO_PATH ]]; then
   doLog "Sonarr sonarr_episodefile_path not found. Maybe a Radarr movie?"
-  VIDEO_PATH=${radarr_movie_path}
+  VIDEO_PATH=${radarr_moviefile_path}
 fi
 
 if [[ -z $VIDEO_PATH ]]; then

--- a/sub-downloader.sh
+++ b/sub-downloader.sh
@@ -3,6 +3,9 @@ set -e
 echo `dirname $0`
 declare LOG_FILE=~/logs/subs-downloader.log
 declare WANTED_FILE=`dirname $0`/wanted/subs.wanted
+declare DOWNLOADER_PROPERTIES=`dirname $0`/downloader.properties
+
+source `dirname $0`/properties_parser.sh
 
 # Sonarr does not show the stdout as part of the log information displayed by the system,
 # So I decided to store the log information by my own.
@@ -12,33 +15,21 @@ function doLog {
 }
 
 function printUsage {
-  msg="Usage: sub-downloader.sh [options]\n\n
-    -l, --languages <languages-list>:\n
-    \t Specify a comma-separated list of languages to download.\n
-    \t example: sub-downloader.sh -l es,en\n\n
+  msg="Usage: sub-downloader.sh\n\n
+    This script relies on dowloader.properties, please fill \n\n
     -h, --help: print this help"
   doLog "$msg"
   exit 1
 }
 
-if [[ $# -eq 0 ]]; then
+if [[ "$1" == '-h' ]]; then
   printUsage
 fi
 
-while [ "$1" != "" ]; do
-  case $1 in
-    "-l" | "--languages")
-      shift
-      declare LANGUAGES=$(echo "-l $1" | sed "s/,/ -l /g")
-      ;;
-    *)
-      printUsage
-      ;;
-  esac
-  shift
-done
-
 doLog "###### Process started at: $(date) ######"
+
+LANGUAGES=`propLanguages $DOWNLOADER_PROPERTIES`
+CREDENTIALS=`propCredentials $DOWNLOADER_PROPERTIES`
 
 declare VIDEO_PATH=${sonarr_episodefile_path}
 if [[ -z $VIDEO_PATH ]]; then
@@ -53,10 +44,10 @@ fi
 
 doLog "Looking for subtitles for: ${VIDEO_PATH}"
 
-doLog "Executing subliminal"
-doLog "subliminal download ${LANGUAGES} ${VIDEO_PATH}"
-subliminal download ${LANGUAGES} "${VIDEO_PATH}" >> $LOG_FILE 2>&1
-  
+doLog "Executing subliminal, using $CREDENTIALS, and language $LANGUAGES"
+COMMAND="subliminal --debug $CREDENTIALS download $LANGUAGES \"$VIDEO_PATH\" >> $LOG_FILE 2>&1"
+eval $COMMAND   
+
 # Look for not found subtitles
 declare LANG_ARRAY=($(echo ${LANGUAGES} | sed "s/-l //g"))
 

--- a/sub-downloader.sh
+++ b/sub-downloader.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 echo `dirname $0`
-declare LOG_FILE=`dirname $0`/sub-downloader.log
-declare WANTED_FILE=`dirname $0`/wanted/subs.wanted
+declare LOG_FILE=~/logs/sonarr-sub-downloader/sub-downloader.log
+declare WANTED_FILE=~/logs/sonarr-sub-downloade/wanted-subs.log
 
 # Sonarr does not show the stdout as part of the log information displayed by the system,
 # So I decided to store the log information by my own.

--- a/wanted/search-wanted.sh
+++ b/wanted/search-wanted.sh
@@ -3,7 +3,9 @@
 declare WANTED_FILE=`dirname $0`/subs.wanted
 
 declare MISSED=""
+echo "#########################################"
 echo "###### Process started at: $(date) ######"
+echo "#########################################"
 
 while IFS=':' read -a line; do
   SOURCE=${line[0]}

--- a/wanted/search-wanted.sh
+++ b/wanted/search-wanted.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source `dirname $0`/../properties_parser.sh
+
+declare DOWNLOADER_PROPERTIES=`dirname $0`/../downloader.properties
 declare WANTED_FILE=`dirname $0`/subs.wanted
 
 declare MISSED=""
@@ -7,17 +10,23 @@ echo "#########################################"
 echo "###### Process started at: $(date) ######"
 echo "#########################################"
 
+LANGUAGE=`propLanguages $DOWNLOADER_PROPERTIES`
+CREDENTIALS=`propCredentials $DOWNLOADER_PROPERTIES`
+
 while IFS=':' read -a line; do
   SOURCE=${line[0]}
   SRT=${line[1]}
-  LANG=`echo $SRT | sed -e "s/\.srt//g" -e "s/.*\(..\)/\1/"`
-  echo "subliminal download -l $LANG $SOURCE"
-  subliminal download -l $LANG "$SOURCE"
+
+  COMMAND="subliminal $CREDENTIALS download $LANGUAGE \"$SOURCE\""
+
+  echo $COMMAND
+  eval $COMMAND
+  
   if [[ ! -f $SRT ]]; then
     IFS=''
     MISSED="$SOURCE:$SRT\n$MISSED"
     echo "Subtitle still not available"
-  else
+  else 
     echo "Great! we have found $SRT"
   fi
 done < "$WANTED_FILE"


### PR DESCRIPTION
Hey! I'm not sure if you keep maintaining this repo, but here it comes anyway :smile: 

**Changelog:**
* [Radarr](https://radarr.video/) support (the script should be configured the same way as with Sonarr)
* Replaced command line arguments with `downloader.properties`. Sonarr v3 won't support custom script arguments anymore. See more at https://github.com/Sonarr/Sonarr/wiki/Custom-Post-Processing-Scripts#arguments

Let me know your thoughts!